### PR TITLE
Screen Usefull Widgets Color TX16S

### DIFF
--- a/Screen Usefull widgets
+++ b/Screen Usefull widgets
@@ -1,0 +1,4 @@
+XTotcels you can see Battery cells values and main baterry value from frsky lipo sensosr.
+XCeles show in screen Minum cell value and RSSI value whit the lower value of both (Can use Cel- , VFAS-, RxBt- you can change in lua script)
+XRssi Show 3 bars with actual value in left side, maxium value in screen middle and minium value at right side of screen  
+XGpsvals Show Ground Speed and Airspeed sensors also with minium values at bottom screen 


### PR DESCRIPTION
You can add the 4 widgets folders in SD CARD Widgets folder and can call in Screen Settings with full screen and top bar enabled but other screen items not allowed.
You can modify main.lua files at your pleasure. No restriction nor garanties. Tested from long time work fine. There are 4 exemples in ZIP files of image screen ( not necesary to add in main widget folder) adn 4 folders with each widgets.

[LUA_Screen_widgets.zip](https://github.com/EdgeTX/lua-scripts/files/8193433/LUA_Screen_widgets.zip)

![XCeles](https://user-images.githubusercontent.com/82335501/156940854-5401b1ad-fd9b-4817-90bc-3bedf5070b0d.png)
![XGpsvals](https://user-images.githubusercontent.com/82335501/156940855-7716b134-3db0-4e74-a9d5-318f95a2bdd6.png)
![XRssi](https://user-images.githubusercontent.com/82335501/156940856-7e1a645b-c732-4767-9b9f-8b726d59e932.png)
![XTotceles](https://user-images.githubusercontent.com/82335501/156940857-4448d7c5-1bbb-4c6b-93cd-b0885c2dee4c.png)
.