### PR TITLE
fix: heading levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Games and other fun Lua scripts are listed [seperately here](/games.md).
 
 ---
 
-# ExpressLRS
+## ExpressLRS
 
 ### [ExpressLRS Configurator](https://www.expresslrs.org/3.0/quick-start/transmitters/lua-howto/)
 LUA configurator for ExpressLRS hardware<br/>
@@ -37,7 +37,9 @@ Display ExpressLRS LinkStats telemetry as well as common Betaflight and iNav fli
 
 <br/>
 
-## [Yaapu telemetry widget](https://github.com/yaapu/FrskyTelemetryScript)
+## GPS
+
+### [Yaapu telemetry widget](https://github.com/yaapu/FrskyTelemetryScript)
 ArduPilot LUA telemetry script for color and B&W.<br/>
 <a href="https://user-images.githubusercontent.com/30294218/198382377-cb48032f-ea5c-4f8d-aa12-f592c1e09358.png" target="_blank" title="Click for larger version"><img src="https://user-images.githubusercontent.com/30294218/198382377-cb48032f-ea5c-4f8d-aa12-f592c1e09358.png" width="250"></a>
 <a href="https://user-images.githubusercontent.com/30294218/216000387-f330a204-b674-48ea-bdaf-64ec33871eb2.png" target="_blank" title="Click for larger version"><img src="https://user-images.githubusercontent.com/30294218/216000387-f330a204-b674-48ea-bdaf-64ec33871eb2.png" width="150"></a>
@@ -46,13 +48,13 @@ ArduPilot LUA telemetry script for color and B&W.<br/>
 
 <br/>
 
-## [Yaapu Horus Mapping Widget](https://github.com/yaapu/HorusMappingWidget)
+### [Yaapu Horus Mapping Widget](https://github.com/yaapu/HorusMappingWidget)
 Offline GPS Mapping Widget for Horus and T16 radios. It supports Ardupilot, iNAV, Betaflight, Crossfire and whatever FC or firmware that can send GPS info to EdgeTX.<br/>
 <a href="https://user-images.githubusercontent.com/30294218/76712734-946a6500-671b-11ea-9fbc-6c779cf4d0b5.png" target="_blank" title="Click for larger version"><img src="https://user-images.githubusercontent.com/30294218/76712734-946a6500-671b-11ea-9fbc-6c779cf4d0b5.png" width="250"></a>
 
 <br/>
 
-## [GPS widget](https://github.com/moschotto/OpenTX_GPS_Telemetry)
+### [GPS widget](https://github.com/moschotto/OpenTX_GPS_Telemetry)
 GPS Telemetry Widget (B&W & Color). Shows total distance traveled, distance from home, as well as both home and last seen telemetry positions. Also logs to file, and has a log viewer so you don't have to worry about losing the coordinates if you turn the transmitter off.</br>
 <a href="https://github.com/moschotto/OpenTX_GPS_Telemetry">
     <img src="https://raw.githubusercontent.com/moschotto/OpenTX_GPS_Telemetry/main/media/description.png" width="250">
@@ -61,7 +63,7 @@ GPS Telemetry Widget (B&W & Color). Shows total distance traveled, distance from
 
 <br/>
 
-## [GPS Plus Code, Home Arrow and AvgBatt widgets](https://github.com/kristjanbjarni/opentx-widgets)
+### [GPS Plus Code, Home Arrow and AvgBatt widgets](https://github.com/kristjanbjarni/opentx-widgets)
 Collection of Colorlcd & B&W widgets. 
 For colorlcd includes GPS lat/long and Google Plus code widget, Home direction/distance widget, and average battery voltage widget.
 For B&W includes GPS Telemetry screen, and Home distance telemetry screen.</br>
@@ -73,7 +75,9 @@ For B&W includes GPS Telemetry screen, and Home distance telemetry screen.</br>
 
 <br/>
 
-## [Switch2 widget](https://repository.justfly.solutions/index.php?view=product&id=115:switch-config)
+## Other
+
+### [Switch2 widget](https://repository.justfly.solutions/index.php?view=product&id=115:switch-config)
 Widget that shows switch positions with customisable icons. Shows all switches with different icons for every switch position.</br>
 Links: [JustFly](https://repository.justfly.solutions/index.php?view=product&id=115:switch-config), [RCGroups](https://www.rcgroups.com/forums/showpost.php?p=50176699&postcount=4012)
 
@@ -83,7 +87,7 @@ Links: [JustFly](https://repository.justfly.solutions/index.php?view=product&id=
 </a>
 <br/>
 
-## [Multi Protocol Module Tools](https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/tree/master/Lua_scripts)
+### [Multi Protocol Module Tools](https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/tree/master/Lua_scripts)
 Scripts to complement the Multi Protocol Module, such as allowing you to configure certain aspects of the module, automacitally name channels, do DSM forward programming, as well as other protocol specific tasks.</br>
 <a href="https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/tree/master/Lua_scripts">
     <img src="https://camo.githubusercontent.com/85db5f399440dee68d8d95ae994aab3f2fbb99d511c97326c0b976f23d17c170/68747470733a2f2f696d672e796f75747562652e636f6d2f76692f6c47794356326b707148552f302e6a7067" width="250">
@@ -92,7 +96,7 @@ Scripts to complement the Multi Protocol Module, such as allowing you to configu
 </a>
 <br/>
 
-## [Spektrum DSM Tools](https://github.com/frankiearzu/DSMTools)
+### [Spektrum DSM Tools](https://github.com/frankiearzu/DSMTools)
 Scripts to use with Spektrum Receivers. It has easy to install zip files versions of:
 - DSM Forward Programming (In collaboration with Multi-Module)
 - Spektrum Telemetry Scripts, Including TextGen for AVIAN ESC programming. Will become telemetry widgets in the future.
@@ -114,7 +118,9 @@ Scripts to use with Spektrum Receivers. It has easy to install zip files version
 
 <br/>
 
-## [Betaflight Setup](https://github.com/betaflight/betaflight-tx-lua-scripts)
+## Telemetery & Flight Controllers
+
+### [Betaflight Setup](https://github.com/betaflight/betaflight-tx-lua-scripts)
 The Betaflight LUA script allows you to change flight controller settings on your radio, such as PID, rates, VTX channels and power, and many more.<br/>
 <a href="https://github.com/betaflight/betaflight-tx-lua-scripts">
     <img src="https://oscarliang.com/ctt/uploads/2021/07/betaflight-lua-script-config-home-menu-screen-options.jpg" width="250">
@@ -122,7 +128,7 @@ The Betaflight LUA script allows you to change flight controller settings on you
 
 <br/>
 
-## [INAV Telemetry Flight Status](https://github.com/iNavFlight/OpenTX-Telemetry-Widget)
+### [INAV Telemetry Flight Status](https://github.com/iNavFlight/OpenTX-Telemetry-Widget)
 Shows you telementry and flight status information. Supports radios with color and black and white screens.<br/>
 <a href="https://github.com/iNavFlight/OpenTX-Telemetry-Widget">
     <img  src="https://github.com/teckel12/LuaTelemetry/blob/master/assets/iNavHorus.png" width="250">
@@ -131,7 +137,7 @@ Shows you telementry and flight status information. Supports radios with color a
 
 <br/>
 
-## [FM2M ToolBox](http://fm2m.jimb40.com/ToolBox.html)
+### [FM2M ToolBox](http://fm2m.jimb40.com/ToolBox.html)
 Feature rich FM2M ToolBox is LUA App focusing on BetaFlight users. Provides dashboard with telemetry overview for all major RC Links,  custom alerts , VTx info and much more. Supports radios with color and black and white screens.<br/>
 <a href="http://fm2m.jimb40.com/ToolBox.html">
 <img src="http://fm2m.jimb40.com/pub/FM2M_ToolBox073_db.png" width="250">
@@ -141,7 +147,7 @@ Feature rich FM2M ToolBox is LUA App focusing on BetaFlight users. Provides dash
 
 <br/>
 
-## [FM2M Widgets Pack](http://fm2m.jimb40.com/download.html)
+### [FM2M Widgets Pack](http://fm2m.jimb40.com/download.html)
 Enhanced Model, Timer, Channels and Analog Clock widgets.<br/>
 <a href="http://fm2m.jimb40.com/download.html">
     <img src="http://fm2m.jimb40.com/assets/images/fm2m-widget-pack-155327-480x272.png" width="250">
@@ -153,7 +159,7 @@ Enhanced Model, Timer, Channels and Analog Clock widgets.<br/>
 
 <br/>
 
-## [TBS Agent Lite](https://www.team-blacksheep.com/products/prod:agentx)
+### [TBS Agent Lite](https://www.team-blacksheep.com/products/prod:agentx)
 LUA configurator for numerous TBS products. Use this instead of Crossfire lua.<br/>
 <a href="https://www.team-blacksheep.com/products/prod:agentx">
     <img src="https://www.team-blacksheep.com/img/gallery/conIkNCQ.jpg" width="250">
@@ -170,7 +176,9 @@ ShowItAll displays various information in a single pane.<br/>
 
 <br/>
 
-## [vu fullscreen image viewer widget for big screens](https://www.schleth.com/fpv/vu-a-simple-image-viewer-for-edgetx-radios-with-big-screens-2113.html)
+## Other
+
+### [vu fullscreen image viewer widget for big screens](https://www.schleth.com/fpv/vu-a-simple-image-viewer-for-edgetx-radios-with-big-screens-2113.html)
 View fullscreen images with layout information or photos, cycle through them and have quick access to your favourite one.<br/>
 <a href="https://www.schleth.com/fpv/vu-a-simple-image-viewer-for-edgetx-radios-with-big-screens-2113.html">
     <img src="https://www.schleth.com/wp-content/uploads/vu-screen1.jpg"  width="250">
@@ -181,7 +189,7 @@ View fullscreen images with layout information or photos, cycle through them and
 
 <br/>
 
-## [EdgeTX Goodies](https://github.com/MadMonkey87/EdgeTX-Goodies)
+### [EdgeTX Goodies](https://github.com/MadMonkey87/EdgeTX-Goodies)
 Some widgets, themes and other scripts for EdgeTX<br/>
 <a href="https://github.com/MadMonkey87/EdgeTX-Goodies">
     <img src="https://github.com/MadMonkey87/EdgeTX-Goodies/blob/main/SCREENSHOTS/screenshot_tx16s_22-08-02_18-49-59.png"  width="250">
@@ -192,7 +200,8 @@ Some widgets, themes and other scripts for EdgeTX<br/>
 
 <br/>
 
-## [Log Viewer](https://github.com/offer-shmuely/edgetx-x10-scripts/wiki/LogViewer)
+
+### [Log Viewer](https://github.com/offer-shmuely/edgetx-x10-scripts/wiki/LogViewer)
 Nice presentation of log file on the field<br>
 no computer needed for logs anymore.
 
@@ -210,7 +219,7 @@ no computer needed for logs anymore.
 
 <br/>
 
-## [Widget for Voltage and Current Telemetry](https://github.com/fdm225/mahRe2)
+### [Widget for Voltage and Current Telemetry](https://github.com/fdm225/mahRe2)
 Displays various battery related data.<br/>
 <a href="https://github.com/fdm225/mahRe2/blob/main/README.md">
     <img src="https://static.rcgroups.net/forums/attachments/6/4/3/0/2/9/a16811177-105-mAhRe2_full_screen.png" width="250">
@@ -221,7 +230,7 @@ Displays various battery related data.<br/>
 
 <br/>
 
-## [Quad Telemetry Dashboard (BW only)](https://github.com/mvaldesshc/advanced-edgetx-dashboard)
+### [Quad Telemetry Dashboard (BW only)](https://github.com/mvaldesshc/advanced-edgetx-dashboard)
 LUA-based dashboard (only for black-and-white display radios).<br/>
 <a href="https://github.com/mvaldesshc/advanced-edgetx-dashboard">
     <img src="https://i.postimg.cc/Jz1CdwTG/opentx-quad-telemetry.gif">
@@ -229,14 +238,14 @@ LUA-based dashboard (only for black-and-white display radios).<br/>
 
 <br/>
 
-## [TSwitch Widget](https://github.com/Ziege-One/TSwitch)
+### [TSwitch Widget](https://github.com/Ziege-One/TSwitch)
 Widget for color screen radios that allows touch buttons via logical switches (in German).<br/>
 <a href="https://github.com/Ziege-One/TSwitch">
     <img src="https://raw.githubusercontent.com/Ziege-One/TSwitch/main/docs/fullscreen.png" width="250">
     <img src="https://raw.githubusercontent.com/Ziege-One/TSwitch/main/docs/widget_status.png" width="250">
 </a>
 
-## [Lap Timer](https://github.com/RadioMasterRC/EdgeTX-LapTimer)
+### [Lap Timer](https://github.com/RadioMasterRC/EdgeTX-LapTimer)
 Advanced lap timer script using as little controls as possible. It stores race and lap data for analysis back at the computer.<br/>
 <a href="https://github.com/RadioMasterRC/EdgeTX-LapTimer">
   <img src="https://github.com/RadioMasterRC/EdgeTX-LapTimer/blob/master/ScreenShot/screen-1.bmp" height="128px"/>
@@ -249,14 +258,14 @@ Advanced lap timer script using as little controls as possible. It stores race a
   <img src="https://github.com/RadioMasterRC/EdgeTX-LapTimer/blob/master/ScreenShot/screen-6.bmp" height="128px"/>
 </a>
 
-## [F3A Caller](https://github.com/jrwieland/F3A)
+### [F3A Caller](https://github.com/jrwieland/F3A)
 Caller for practicing F3A pattern - Updated to 2024 Season<br/>
 <a href="https://github.com/jrwieland/F3A">
 <img src="https://github.com/jrwieland/F3A/blob/main/Screenshots/p-21.png">
 <img src="https://github.com/jrwieland/F3A/blob/main/Screenshots/f25.png">
 </a>
 
-## [TaraniTunes](https://github.com/jrwieland/TaraniTunes-v4.x)
+### [TaraniTunes](https://github.com/jrwieland/TaraniTunes-v4.x)
 Enhanced music player for OpenTX & EdgeTX radios Multiple Playlists allow you to listen to your music while flying Your RC<br/>
 <a href="https://github.com/jrwieland/TaraniTunes-v4.x">
 <img src="https://github.com/jrwieland/TaraniTunes-v4.x/blob/master/Color%20Screen%20Widget/Screenshots3/Features.png" width="500">
@@ -266,7 +275,7 @@ Enhanced music player for OpenTX & EdgeTX radios Multiple Playlists allow you to
 <img src="https://github.com/jrwieland/TaraniTunes-v4.x/blob/master/Screenshots/Customize.PNG" width="300">
 </a>
 
-## [GPS QR Code generator](https://github.com/alufers/edgetx-gps-qrcode)
+### [GPS QR Code generator](https://github.com/alufers/edgetx-gps-qrcode)
 Generates a QR code of last GPS coordinates received (for black-and-white screen radios)<br/>
 <a href="https://github.com/alufers/edgetx-gps-qrcode">
 <img src="https://raw.githubusercontent.com/alufers/edgetx-gps-qrcode/master/docs/sim-screenshot.png" width="500">
@@ -274,21 +283,21 @@ Generates a QR code of last GPS coordinates received (for black-and-white screen
 <img src="https://raw.githubusercontent.com/alufers/edgetx-gps-qrcode/master/docs/x9dp-screenshot.png" width="500">
 </a>
 
-## [Battery Percentage and mAh Used](https://github.com/jrwieland/Battery-mAh)
+### [Battery Percentage and mAh Used](https://github.com/jrwieland/Battery-mAh)
 Widget to display the levels of Lipo/HV-Lipo battery with mAh used based on battery voltage from 'Cels' sensor (FLVSS)<br/>
 <a href="https://github.com/jrwieland/Battery-mAh">
 <img src="https://github.com/jrwieland/Battery-mAh/blob/main/Screenshots/4_2lipo.png" width="400">
 <img src="https://github.com/jrwieland/Battery-mAh/blob/main/Screenshots/4_35lipo.png" width="400">  
 </a>
 
-## [TxBatTele](https://github.com/derelict/TxBatTele)
+### [TxBatTele](https://github.com/derelict/TxBatTele)
 Battery and Telemetry Monitoring LUA Widget which tries to rely as less as possible on radio settings (Everything is defined in the Script). So no need for "manual" Logical Switches or Custom Functions.
 
 <a href="https://github.com/derelict/TxBatTele">
 <img src="https://github.com/derelict/TxBatTele/blob/main/screenshots/demovid.gif">
 </a>
 
-## [SwitchOverview](https://github.com/druckgott/getswitchesWdgets/)
+### [SwitchOverview](https://github.com/druckgott/getswitchesWdgets/)
 A simple widget to display switches which are configured in special function and have a PLAY_TRACK behind.
 
 <a href="https://github.com/druckgott/getswitchesWdgets">
@@ -296,14 +305,14 @@ A simple widget to display switches which are configured in special function and
 </a>
 
 
-## [Log Viewer (BW only)](https://github.com/nikbg3/EdgeTXLogViewerBW)
+### [Log Viewer (BW only)](https://github.com/nikbg3/EdgeTXLogViewerBW)
 Simple EdgeTX LUA script for BW radios to read logs files on the display. Rotary wheel is used to change the read value. Back is used to switch between modes. i.e., changing columns, rows or files.
 
 <a href="https://github.com/nikbg3/EdgeTXLogViewerBW">
 <img src="https://github.com/user-attachments/assets/43b69333-3dcc-4186-a3e8-68544e4cb3fc">
 </a>
 
-## [GPS Viewer](https://github.com/ktaliaferro/gps-viewer)
+### [GPS Viewer](https://github.com/ktaliaferro/gps-viewer)
 Plot logged flight telemetry data on a map of your airfield.
 
 <a href="https://github.com/ktaliaferro/gps-viewer">


### PR DESCRIPTION
The heading levels are really wierd.

ExpressLRS is a second H1 and I think it intended to be a sub headers

Yet also it's the only subheader and all other scripts are beneath it.

This commit changes the README so ExpressLRS is a H2 and adds others (somewhat correctly) while moving the links to H3.