### PR TITLE
Rotorflight fancy widget dashboard (LVGL Lua dev - contest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,3 +373,43 @@ Log each flight GPS coordinates to a separate GPX file.
 <a href="https://github.com/poweredjj/gpslog">
 <img src="https://github.com/poweredjj/gpslog/raw/main/screenshot.png"  width="300">
 </a>
+
+
+
+<br/><br/><br/>
+
+## [Rotorflight Dashboard widget (for Heli flights)](https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2)
+
+* part of the rf2-touch-suite for edgexTx
+* design for [rotorflight2](https://www.rotorflight.org/)
+* the widget have 3 types of views
+
+<img src="https://github.com/user-attachments/assets/7a98c153-4e23-4344-b4e4-c2acba6d116c" width="60">
+
+<br>
+dashboard type 1 
+
+<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2"> 
+    <img src="https://github.com/user-attachments/assets/9b95d285-7881-4286-883a-ad68321e9f7f" width="550">
+</a>
+
+<br>
+dashboard type 2
+
+<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2"> 
+    <img src="https://github.com/user-attachments/assets/6c051557-f94b-432d-bda1-fcacb36c9c0d" width="550">
+</a>
+
+<br>
+dashboard style 3
+
+<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2"> 
+    <img src="https://github.com/user-attachments/assets/d2bcee9d-e5be-42a0-b2cc-868a900c5040" width="550">
+</a>
+
+
+
+<br/><br/><br/>
+
+
+

--- a/README.md
+++ b/README.md
@@ -374,7 +374,6 @@ Log each flight GPS coordinates to a separate GPX file.
 <img src="https://github.com/poweredjj/gpslog/raw/main/screenshot.png"  width="300">
 </a>
 
-
 ### [Rotorflight Dashboard widget (for Heli flights)](https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dashboard)
 
 * part of the rf2-touch-suite for EdgeTX

--- a/README.md
+++ b/README.md
@@ -375,41 +375,25 @@ Log each flight GPS coordinates to a separate GPX file.
 </a>
 
 
+### [Rotorflight Dashboard widget (for Heli flights)](https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dashboard)
 
-<br/><br/><br/>
-
-## [Rotorflight Dashboard widget (for Heli flights)](https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2)
-
-* part of the rf2-touch-suite for edgexTx
-* design for [rotorflight2](https://www.rotorflight.org/)
-* the widget have 3 types of views
+* part of the rf2-touch-suite for EdgeTX
+* designed for [rotorflight2](https://www.rotorflight.org/)
+* the widget has 3 types of views
 
 <img src="https://github.com/user-attachments/assets/7a98c153-4e23-4344-b4e4-c2acba6d116c" width="60">
 
-<br>
-dashboard type 1 
-
-<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2"> 
+#### Dashboard type 1
+<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dashboard"> 
     <img src="https://github.com/user-attachments/assets/9b95d285-7881-4286-883a-ad68321e9f7f" width="550">
 </a>
 
-<br>
-dashboard type 2
-
-<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2"> 
+#### Dashboard type 2
+<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dashboard"> 
     <img src="https://github.com/user-attachments/assets/6c051557-f94b-432d-bda1-fcacb36c9c0d" width="550">
 </a>
 
-<br>
-dashboard style 3
-
-<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2"> 
+#### Dashboard style 3
+<a href="https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dashboard"> 
     <img src="https://github.com/user-attachments/assets/d2bcee9d-e5be-42a0-b2cc-868a900c5040" width="550">
 </a>
-
-
-
-<br/><br/><br/>
-
-
-


### PR DESCRIPTION
Hey Rotorflight pilots

I’ve built 3 new dashboards that work automatically with Rotorflight
the style can be chosen inside the widget options
 


## Style1
Vibrant & Feature-Rich (My Design) – colorful, sharp, shows all the key stuff: total or cell voltage, battery capacity from the FC, auto model image and name via craft-name.
![image](https://github.com/user-attachments/assets/9b95d285-7881-4286-883a-ad68321e9f7f)

## Style2
Sleek & Calm Version – similar to #1 but with smoother, more chill visuals.
![image](https://github.com/user-attachments/assets/6c051557-f94b-432d-bda1-fcacb36c9c0d)

## Style3
Modern Minimalist (By VenbS) – clean, stylish, still pulls everything automatically: model pic, name, battery specs, and min voltage from the FC.

![image](https://github.com/user-attachments/assets/d535d959-fea3-4255-8377-42761b9ebfa5)

![image](https://github.com/user-attachments/assets/4222506f-affa-46b7-ba72-31c3e5a8d17a)

---

Here is a short enhancement
if you press the widget to change for full-screen
the presentation will be changed, and pids from all banks will be presented side by side 
so easy compare can be achieved


![image](https://github.com/user-attachments/assets/689e0a67-0538-48e4-ba88-edef2a5665cf)

![image](https://github.com/user-attachments/assets/16a3ec86-7e1b-4cca-80b8-19d3417d98cf)

![image](https://github.com/user-attachments/assets/efad4826-7ae9-4784-b79c-1707e6aea4ca)




Download from:
https://github.com/offer-shmuely/rf2-touch-suite-edgeTx

wiki:
https://github.com/offer-shmuely/rf2-touch-suite-edgeTx/wiki/widget-%E2%80%90-rf2_dash2


<br><br><br><br>
First press👍, then pick your favorite GUI
* Style :one: →  :tada:   
* Style :two: →  :rocket:
* Style :three: →  :eyes:

Please do NOT post bellow the type of gui you like, they are ignored, only the icon by emoji count
