### PR TITLE
fix(ci): sync issue templates directly in script-submission.yml

### DIFF
--- a/.github/workflows/script-submission.yml
+++ b/.github/workflows/script-submission.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Validate scripts.json
         run: uv run tools/validate_scripts.py --scripts-json scripts.json
 
+      - name: Sync issue template tags/categories
+        run: uv run tools/sync_issue_template_options.py --write
+
       - name: Configure git identity
         run: |
           git config user.name  "github-actions[bot]"
@@ -63,7 +66,9 @@ jobs:
         run: |
           BRANCH="add-script/${ISSUE_NUMBER}"
           git checkout -b "$BRANCH"
-          git add scripts.json
+          git add scripts.json scripts.schema.json \
+            .github/ISSUE_TEMPLATE/add-script.yml \
+            .github/ISSUE_TEMPLATE/update-script.yml
           VERB="Add"
           if [ "$MODE" = "patch" ]; then VERB="Update"; fi
           git commit -m "feat(scripts): ${VERB} script from issue #${ISSUE_NUMBER}
@@ -133,7 +138,7 @@ jobs:
                 "- A script with this name already exists in `scripts.json` (insert mode)",
                 "- The script name was not found in `scripts.json` (update mode)",
                 "- A required field was left blank",
-                "- The selected Category does not match a known value",
+                "- No Category was selected and no New Category was provided",
                 "- The Info URL is missing or does not start with `http://` or `https://`",
                 "",
                 "Please check the [workflow run](" +


### PR DESCRIPTION
## Summary
`validate-issue-templates.yml`'s `push`-triggered `sync` job was designed to self-heal bot-created branches automatically, but that never actually happened: `script-submission.yml` creates its branches via `git push origin "$BRANCH"` using the default `GITHUB_TOKEN`, and GitHub Actions suppresses new workflow-triggering events (including `push`) for `GITHUB_TOKEN`-authored pushes. That's the same rule that (correctly) prevents `sync`'s own corrective commits from re-triggering itself — I just didn't realize it also silently killed the trigger the whole mechanism depended on for the bot-created case.

Confirmed against two real submissions merged after #65 landed: PR #67 and #68 both introduced new tags and landed with a permanently-failing `check` and zero `push`-event workflow runs on their branch — no auto-fix ever ran.

## Fix
Run `uv run tools/sync_issue_template_options.py --write` directly in `script-submission.yml`, right before the commit step, and include the resulting files (`scripts.schema.json`, both templates) in that same commit. The schema/templates are now correct from the very first commit of every bot-generated PR, so `check` passes immediately — no reliance on retriggering at all.

The `push`/`sync` job in `validate-issue-templates.yml` is unchanged and still useful as a backstop for genuine human-authored pushes (e.g. a maintainer hand-editing `scripts.json` directly), which aren't subject to this suppression.

Also fixes a stale line in the failure-comment text that still referenced the category-enum rejection removed in #65.

## Test plan
- [x] Simulated the full flow locally: `issue_to_scripts.py` insert with a new tag → `sync_issue_template_options.py --write` → confirmed the new tag lands in both `scripts.schema.json` and the template in the same pass
- [x] `uv run tools/test_sync_issue_template_options.py` — 10 tests pass
- [x] `uv run tools/sync_issue_template_options.py --check` on `main` — in sync
- [x] YAML validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)